### PR TITLE
Fix secret project name matching

### DIFF
--- a/lua/testaustime.lua
+++ b/lua/testaustime.lua
@@ -72,7 +72,7 @@ function getheartbeatdata()
     local project_name = root:match("/([^/]+)$")
 
     for _, ignored_project_name in ipairs(testaustime_secret_projects) do
-        if root:find(ignored_project_name) ~= nil then
+        if root:find(ignored_project_name, 1, true) ~= nil then
             project_name = "hidden"
         end
     end


### PR DESCRIPTION
This fix changes the find to use plain search instead of pattern matching, so it will also match characters like "." and "-".